### PR TITLE
Enhance Stripe webhook handling and product metadata types

### DIFF
--- a/src/app/(app)/api/stripe/webhook/route.ts
+++ b/src/app/(app)/api/stripe/webhook/route.ts
@@ -51,6 +51,13 @@ export async function POST(request: Request) {
         case 'checkout.session.completed': {
           data = event.data.object;
 
+          if (data.payment_status !== 'paid') {
+            console.log(
+              `Skipping session ${data.id}: payment_status is ${data.payment_status}`,
+            );
+            break;
+          }
+
           if (!data.metadata?.userId) {
             throw new Error('User ID is required');
           }
@@ -85,12 +92,20 @@ export async function POST(request: Request) {
             .data as ExpandedLineItem[];
 
           for (const lineItem of lineItems) {
+            const productId = lineItem.price.product.metadata.id;
+            if (!productId) {
+              console.log(
+                `Skipping line item ${lineItem.id}: missing product metadata.id`,
+              );
+              continue;
+            }
+
             try {
               await payloadEvent.create({
                 collection: 'orders',
                 data: {
                   user: user.id,
-                  product: lineItem.price.product.metadata.id,
+                  product: productId,
                   stripeCheckoutSessionId: `${data.id}-${lineItem.id}`,
                   stripeAccountId: event.account,
                   name: lineItem.price.product.name,
@@ -98,10 +113,12 @@ export async function POST(request: Request) {
               });
             } catch (error) {
               // Skip if order already exists (duplicate webhook)
-              if (
-                error instanceof Error &&
-                error.message.includes('duplicate')
-              ) {
+              const isDuplicate =
+                typeof error === 'object' &&
+                error !== null &&
+                'code' in error &&
+                (error as { code: unknown }).code === 11000;
+              if (isDuplicate) {
                 console.log(
                   `Order already exists for session ${data.id}, line item ${lineItem.id}`,
                 );

--- a/src/modules/checkout/server/procedures.ts
+++ b/src/modules/checkout/server/procedures.ts
@@ -173,7 +173,7 @@ export const checkoutRouter = createTRPCRouter({
                 stripeAccountId: tenant.stripeConnectAccountId,
                 id: product.id,
                 name: product.name,
-                price: product.price,
+                price: String(product.price),
               } as ProductMetadata,
             },
             unit_amount: Math.round(product.price * 100),

--- a/src/modules/checkout/types.ts
+++ b/src/modules/checkout/types.ts
@@ -4,7 +4,7 @@ export type ProductMetadata = {
   stripeAccountId: string;
   id: string;
   name: string;
-  price: number;
+  price: string;
 };
 
 export type CheckoutSessionMetadata = {

--- a/src/modules/products/ui/components/tags-filter.tsx
+++ b/src/modules/products/ui/components/tags-filter.tsx
@@ -24,7 +24,7 @@ export function TagsFilter({ tags, onTagsChange }: TagsFilterProps) {
       { limit: DEFAULT_TAGS_LIMIT },
       {
         getNextPageParam: (lastPage) =>
-          lastPage.docs.length > 0 ? lastPage.nextPage : undefined,
+          lastPage.hasNextPage ? lastPage.nextPage : undefined,
       }
     )
   );


### PR DESCRIPTION
- Added a check to skip processing sessions with a payment status other than 'paid' in the Stripe webhook.
- Improved error handling for duplicate orders by checking the error code.
- Updated product metadata type to change the price from number to string for consistency.
- Ensured price is converted to a string when creating product metadata in checkout procedures.
- Modified tags filter logic to use hasNextPage for pagination.